### PR TITLE
Don't overwrite commit message with PR info

### DIFF
--- a/lib/pages/merge.js
+++ b/lib/pages/merge.js
@@ -42,10 +42,6 @@ module.exports = React.createClass({displayName: 'MergePage',
         if (event.target.textContent === SQUASH_MERGE) {
             commitMessage += `\n\nSquash-merged from pull request #${pr.getId()}`;
         }
-        else if (event.target.textContent === MERGE_WITHOUT_SQUASH) {
-            commitMessage = `Merge pull request #${pr.getId()} from ` +
-                `${pr.getSource().getUser().name}/${pr.getSource().getRef()}`;
-        }
 
         this.setState({
             flowStage: "wantCommitMessage",


### PR DESCRIPTION
Github does this automatically, so this was leading to duplicate
information.

Also, preserve the PR title and body in the merge commit message by
default, like github does.
